### PR TITLE
Fix `accessors_and_observers_on_newline` swiftlint rule

### DIFF
--- a/{{ cookiecutter.name }}/.swiftlint.yml
+++ b/{{ cookiecutter.name }}/.swiftlint.yml
@@ -51,5 +51,5 @@ custom_rules:
     message: "Enum cases should always start with a newline."
   accessors_and_observers_on_newline:
     name: "Property accessors and observers on newline"
-    regex: "^\\s*(get|set|didSet|willSet)[\\h\\S]*\\{[\\h\\S]+$"
+    regex: "^\\s*(get|set|didSet|willSet)[\\h\\S]\\{[\\h\\S]+$"
     message: "Property accessors and observers should always start with a newline."


### PR DESCRIPTION
Fixed wrong triggering of `accessors_and_observers_on_newline` SwiftLint rule.

Rule is no longer triggering for following code: 
```
settingsButton.configureFrame { maker in
    maker.center()
}
```
Regex tested [here](https://regex101.com/r/3RedBL/3).